### PR TITLE
fixed the misplaced comma in the code snippet

### DIFF
--- a/docs/features/environment.md
+++ b/docs/features/environment.md
@@ -41,8 +41,8 @@ module.exports = {
             "NODE_ENV": "development"
         },
         env_production: {
-            "PORT": 80
-            "NODE_ENV": "production",
+            "PORT": 80,
+            "NODE_ENV": "production"
         }
       }
   ]


### PR DESCRIPTION
```
env_production: {
            "PORT": 80
            "NODE_ENV": "production",
}
```
Comma was misplaced in the above code snippet, it should be placed after the port key value pair. Fixed that issue to 
```
env_production: {
            "PORT": 80,
            "NODE_ENV": "production"
}
```

Thanks
